### PR TITLE
LCH-1786 SFTP server with IP blocklisting

### DIFF
--- a/sftp/README.md
+++ b/sftp/README.md
@@ -2,4 +2,8 @@
 
 This configuration should serve as a sample for configuring a SFTP server on DXP Cloud using IP allowlist.
 
+Dockerfiles use popular images for each services, and contain minimal customizations to make it work.
+LCP.json files also contain the minimum configuration needed for the service to work properly.
+the sftp-server/users.conf file specify the list of users, their passwords their User IDs and Group IDs, in that order. 
+
 This is not officially supported by Liferay Cloud.

--- a/sftp/README.md
+++ b/sftp/README.md
@@ -1,0 +1,5 @@
+# SFTP SERVER SAMPLE
+
+This configuration should serve as a sample for configuring a SFTP server on DXP Cloud using IP allowlist.
+
+This is not officially supported by Liferay Cloud.

--- a/sftp/proxy/Dockerfile
+++ b/sftp/proxy/Dockerfile
@@ -1,0 +1,4 @@
+FROM nginx:stable
+EXPOSE 22
+COPY ./sftp.conf /etc/nginx/sftp.conf
+RUN printf "\n include /etc/nginx/sftp.conf;\n" >> /etc/nginx/nginx.conf

--- a/sftp/proxy/LCP.json
+++ b/sftp/proxy/LCP.json
@@ -1,0 +1,14 @@
+{
+  "kind": "Deployment",
+  "id": "proxy",
+  "memory": 512,
+  "cpu": 1,
+  "scale": 1,
+  "ports": [
+    {
+      "port": 22,
+      "external": true
+    }
+  ],
+  "portsExternalTrafficPolicy": "Local"
+}

--- a/sftp/proxy/sftp.conf
+++ b/sftp/proxy/sftp.conf
@@ -1,10 +1,14 @@
-stream { 
+stream {
 
-    server { 
-#        listen 22 proxy_protocol;
+    server {
+        #the port where the external service (proxy) will receive connections
         listen 22;
+        #the sftp service and port where it will route connections to. sftp is the name as defined in the
+        #LCP.json file on the sftp-server folder, on the "id" attribute
         proxy_pass sftp:22;
-        allow 177.220.178.165;
-        deny all; 
-    }    
+        #the list of IP addresses this service will accept, must come before the deny all directive
+        allow 1.2.3.4;
+        #directive to deny all other IPs not explicitly allowed
+        deny all;
+    }
 }

--- a/sftp/proxy/sftp.conf
+++ b/sftp/proxy/sftp.conf
@@ -1,0 +1,10 @@
+stream { 
+
+    server { 
+#        listen 22 proxy_protocol;
+        listen 22;
+        proxy_pass sftp:22;
+        allow 177.220.178.165;
+        deny all; 
+    }    
+}

--- a/sftp/sftp-server/Dockerfile
+++ b/sftp/sftp-server/Dockerfile
@@ -1,0 +1,5 @@
+FROM atmoz/sftp
+COPY ./users.conf /etc/sftp/users.conf
+RUN /bin/mkdir -p /home/user/files
+RUN /bin/chown -R 1001:100 /home/user
+ENTRYPOINT ["/entrypoint"]

--- a/sftp/sftp-server/LCP.json
+++ b/sftp/sftp-server/LCP.json
@@ -1,0 +1,13 @@
+{
+  "kind": "Deployment",
+  "id": "sftp",
+  "memory": 512,
+  "cpu": 1,
+  "scale": 1,
+  "ports": [
+    {
+      "port": 22,
+      "external": true
+    }
+  ]
+}

--- a/sftp/sftp-server/users.conf
+++ b/sftp/sftp-server/users.conf
@@ -1,0 +1,1 @@
+user:password:1001:100


### PR DESCRIPTION
LCH-1786 initial commit of SFTP server running on DXP Cloud behind an nginx proxy that takes care of the IP block listing